### PR TITLE
Disable Product Structured data from Admin 

### DIFF
--- a/Block/Richsnippets/Product.php
+++ b/Block/Richsnippets/Product.php
@@ -2,9 +2,9 @@
 
 namespace Mageplaza\Seo\Block\Richsnippets;
 
-use Mageplaza\Seo\Block\Abstractt;
+use Mageplaza\Seo\Block\Richsnippets;
 
-class Product extends Abstractt
+class Product extends Richsnippets
 {
     public function getGeneralConfig($code)
     {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -121,6 +121,11 @@
                     <comment>
                         <![CDATA[ Learn more <a href="https://mageplaza.freshdesk.com/support/solutions/articles/6000122361--rich-snippets/">Rich Snippets</a> ]]></comment>
                 </field>
+                <field id="enable_product" translate="label comment" type="select" sortOrder="11" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Enable Product Structured Data</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="custom" translate="label comment" type="select" sortOrder="15" showInDefault="1"
                        showInWebsite="1" showInStore="1">
                     <label>Enable Organization Information</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -125,6 +125,9 @@
                        showInWebsite="1" showInStore="1">
                     <label>Enable Product Structured Data</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[ Disable this feature if your theme or module implements it's own product snippets ]]>
+                    </comment>
                 </field>
                 <field id="custom" translate="label comment" type="select" sortOrder="15" showInDefault="1"
                        showInWebsite="1" showInStore="1">

--- a/view/frontend/templates/richsnippets/jsonld/product.phtml
+++ b/view/frontend/templates/richsnippets/jsonld/product.phtml
@@ -4,7 +4,7 @@
  */
 ?>
 
-<?php if ($block->getProduct()): ?>
+<?php if ($block->getProduct() && $block->getRichsnippetsHelper('enable_product')): ?>
     <?php $product = $block->getProduct(); ?>
     <!--    Product Rich Snippets by Mageplaza SEO-->
     <script type="application/ld+json">


### PR DESCRIPTION
Hi Sam

This is my proposal to allow disabling of the Product structured data for users who wish to implement their own structured data via a custom theme like luma. This solves the issue of duplicate product snippets on the product view page.

Regards
Lance